### PR TITLE
Feature/csrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,27 @@
 [![Quality](https://img.shields.io/badge/quality-experiment-red)](https://curity.io/resources/code-examples/status/)
 [![Availability](https://img.shields.io/badge/availability-source-blue)](https://curity.io/resources/code-examples/status/)
 
-A plugin to demonstrate how to get an access token from an encrypted BFF cookie via LUA.
+A LUA plugin to demonstrate how to handle translation from secure SameSite cookies to access tokens.\
+This is used within a wider `Back End for Front End` solution when the SPA makes calls to APIs.
 
-## Documentation
+## Configuration
 
+The plugin is configured with properties in the following manner:
 
+```yaml
+plugins:
+  - name: bff-token
+    config:
+      encryption_key: NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP
+      cookie_name_prefix: example
+      trusted_web_origin: http://www.example.com
+```
+
+| Property | Description |
+| -------- | ----------- |
+| Encryption Key | The encryption key used by the BFF API to create AES256 encrypted SameSite cookies |
+| Cookie Name Prefix | The prefix used in the SPA's cookie name, typically representing a company or product |
+| Trusted Web Origin | The web origin from which the BFF will accept secure cookies |
 
 ## More Information
 

--- a/plugin/access.lua
+++ b/plugin/access.lua
@@ -12,10 +12,7 @@ local function error_response(status, code, message, config)
     local jsonData = '{"code":"' .. code .. '", "message":"' .. message .. '"}'
     ngx.status = status
     ngx.header['content-type'] = 'application/json'
-
     ngx.header['Access-Control-Allow-Origin'] = config.trusted_web_origin
-    ngx.header['Access-Control-Allow-Credentials'] = 'true'
-
     ngx.say(jsonData)
     ngx.exit(status)
 end

--- a/plugin/access.lua
+++ b/plugin/access.lua
@@ -5,13 +5,17 @@ local string = require "string"
 local table = require "table"
 
 --
--- Return errors due to invalid token cookie
+-- Return errors to the browser and ensure that the browser can read the response
 --
-local function error_response(status, code, message)
+local function error_response(status, code, message, config)
 
     local jsonData = '{"code":"' .. code .. '", "message":"' .. message .. '"}'
     ngx.status = status
     ngx.header['content-type'] = 'application/json'
+
+    ngx.header['Access-Control-Allow-Origin'] = config.trusted_web_origin
+    ngx.header['Access-Control-Allow-Credentials'] = 'true'
+
     ngx.say(jsonData)
     ngx.exit(status)
 end
@@ -19,8 +23,8 @@ end
 --
 -- Return a generic message for all three of these error categories
 --
-local function unauthorized_request_error_response()
-    error_response(ngx.HTTP_UNAUTHORIZED, "unauthorized", "The request failed cookie authorization")
+local function unauthorized_request_error_response(config)
+    error_response(ngx.HTTP_UNAUTHORIZED, "unauthorized", "The request failed cookie authorization", config)
 end
 
 local function split(inputstr, sep)
@@ -81,20 +85,20 @@ function _M.run(config)
     local web_origin = ngx.req.get_headers()["origin"]
     if not web_origin or web_origin ~= config.trusted_web_origin  then
         ngx.log(ngx.WARN, "The request was from an untrusted web origin")
-        unauthorized_request_error_response()
+        unauthorized_request_error_response(config)
     end
 
     -- Next verify that the main cookie was received and get the access token
     local at_cookie, err = cookie:get(config.cookie_name_prefix .. "-at")
     if err or not at_cookie then
         ngx.log(ngx.WARN, get_error_message("No access token cookie was sent with the request", err))
-        unauthorized_request_error_response()
+        unauthorized_request_error_response(config)
     end
 
     local access_token, err = decrypt_cookie(at_cookie, config.encryption_key)
     if err or not access_token then
         ngx.log(ngx.WARN, get_error_message("Error when decrypting access token cookie - ", err))
-        unauthorized_request_error_response()
+        unauthorized_request_error_response(config)
     end
 
     -- For data changing requests we also expect a CSRF header to be sent with the double submit cookie
@@ -103,19 +107,19 @@ function _M.run(config)
         local csrf_cookie, err = cookie:get(config.cookie_name_prefix .. "-csrf")
         if err or not csrf_cookie then
             ngx.log(ngx.WARN, get_error_message("No CSRF cookie was sent with the request", err))
-            unauthorized_request_error_response()
+            unauthorized_request_error_response(config)
         end
 
         local csrf_token, err = decrypt_cookie(csrf_cookie, config.encryption_key)
         if err or not csrf_token then
             ngx.log(ngx.WARN, get_error_message("Error when decrypting CSRF cookie", err))
-            unauthorized_request_error_response()
+            unauthorized_request_error_response(config)
         end
 
         local csrf_header = ngx.req.get_headers()["x-" .. config.cookie_name_prefix .. "-csrf"]
         if not csrf_header or csrf_header ~= csrf_token  then
             ngx.log(ngx.WARN, get_error_message("Invalid or missing CSRF request header", err))
-            unauthorized_request_error_response()
+            unauthorized_request_error_response(config)
         end
     end
 

--- a/plugin/access.lua
+++ b/plugin/access.lua
@@ -13,6 +13,7 @@ local function error_response(status, code, message, config)
     ngx.status = status
     ngx.header['content-type'] = 'application/json'
     ngx.header['Access-Control-Allow-Origin'] = config.trusted_web_origin
+    ngx.header['Access-Control-Allow-Credentials'] = 'true'
     ngx.say(jsonData)
     ngx.exit(status)
 end

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -5,7 +5,8 @@ return {
             type = "record",
             fields = {
                 { encryption_key = { type = "string", required = true } },
-                { cookie_name_prefix = { type = "string", required = false, default = "example-bff" } }
+                { cookie_name_prefix = { type = "string", required = false, default = "bff" } },
+                { trusted_web_origin = { type = "string", required = false } }
             }
         }}
     }

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -6,7 +6,7 @@ return {
             fields = {
                 { encryption_key = { type = "string", required = true } },
                 { cookie_name_prefix = { type = "string", required = false, default = "bff" } },
-                { trusted_web_origin = { type = "string", required = false } }
+                { trusted_web_origin = { type = "string", required = true } }
             }
         }}
     }


### PR DESCRIPTION
Add CSRF checks to the BFF plugin as agreed in the discussion with Daniel. 

Also fixed CORS so that the SPA can read the error response. In my testing I found that [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) is needed in order for JS to read the response for a CORS credentials request and the Mozilla page says this also.

Feel free to tweak when I am away if needed, but it will be good to get this merged as part of the BFF release 1. Please update the [deploy.sh script](https://github.com/curityio/web-oauth-via-bff/blob/dev/deployment/deploy.sh#L24) when complete, to remove the commented lines that use a feature branch.