### PR TITLE
Feature/cookie updates

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -19,9 +19,9 @@ if [ "$PROFILE" != 'openresty' ] && [ "$PROFILE" != 'kong' ]; then
 fi
 
 #
-# Supply the encryption key as an environment variable
+# Supply the 32 byte encryption key for AES256 as an environment variable
 #
-export ENCRYPTION_KEY='NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP'
+export ENCRYPTION_KEY='4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50'
 
 #
 # For Kong we must update a template file

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,7 +5,10 @@ services:
   # Use Kong Open Source as the reverse proxy when the kong profile is set on the command line
   #
   kong:
-    image: kong:2.6.0-alpine
+    image: custom_kong:2.6.0-alpine
+    build:
+      context: .
+      dockerfile: ./kong/Dockerfile
     hostname: kongserver
     ports:
       - 3000:3000

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,7 +28,10 @@ services:
   # Use OpenResty as the reverse proxy when the openresty profile is set on the command line
   #
   openresty:
-    image: openresty/openresty:1.19.9.1-bionic
+    image: custom_openresty/openresty:1.19.9.1-bionic
+    build:
+      context: .
+      dockerfile: ./openresty/Dockerfile
     hostname: openrestyserver
     ports:
       - 3000:3000

--- a/deploy/kong/Dockerfile
+++ b/deploy/kong/Dockerfile
@@ -1,0 +1,4 @@
+FROM kong:2.6.0-alpine
+USER root
+RUN luarocks install lua-resty-openssl
+USER kong

--- a/deploy/openresty/Dockerfile
+++ b/deploy/openresty/Dockerfile
@@ -1,0 +1,2 @@
+FROM openresty/openresty:1.19.9.1-bionic
+RUN luarocks install lua-resty-openssl

--- a/doc/kong.md
+++ b/doc/kong.md
@@ -10,7 +10,7 @@ The `deploy/kong/kong.yml` file configures the plugin with these details for tes
 plugins:
   - name: oauth-proxy
     config:
-      encryption_key: NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP
+      encryption_key: 4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50
       cookie_name_prefix: example
       trusted_web_origins:
       - http://www.example.com

--- a/doc/openresty.md
+++ b/doc/openresty.md
@@ -11,7 +11,7 @@ The `deploy/openresty/nginx.conf` file configures the plugin with these details 
 rewrite_by_lua_block {
 
     local config = {
-        encryption_key = 'NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP',
+        encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
         cookie_name_prefix = 'example',
         trusted_web_origins = {
             'http://www.example.com'

--- a/plugin/oauth-proxy.lua
+++ b/plugin/oauth-proxy.lua
@@ -84,7 +84,7 @@ local function decrypt_cookie(encrypted_cookie, encryption_key_hex)
     local ciphertext_bytes = string.sub(all_bytes, offset, #all_bytes - GCM_TAG_SIZE)
 
     offset = #all_bytes - GCM_TAG_SIZE + 1
-    local tag_bytes = string.sub(all_bytes, offset, #all_bytes)
+    local tag_bytes = string.sub(all_bytes, offset)
 
     local cipher = cipher.new('aes-256-gcm')
     local encryption_key_bytes = from_hex(encryption_key_hex)


### PR DESCRIPTION
Main changes are:
- Use authenticated symmetric encryption (AES256-GCM), so that tampered cookie bytes return a 401
- Use base64url encoded bytes, to reduce wire size by one third

Note that I've moved the interop library to Bitbucket (under MISC), as recommended by Travis:
https://bitbucket.org/curity/token-handler-encryption-interop