### PR TITLE
CORS refinements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# The module is coded in C, so prevent tests changing the GitHub language displayed
+t/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# The module is coded in C, so prevent tests changing the GitHub language displayed
+# The module is coded in LUA, so prevent tests changing the GitHub language displayed
 t/* linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 response.txt
 kong.yml
 t/servroot
+encryption.key

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OAuth Proxy Plugin for NGINX LUA Systems
 
-[![Quality](https://img.shields.io/badge/quality-production-green)](https://curity.io/resources/code-examples/status/)
+[![Quality](https://img.shields.io/badge/quality-test-yellow)](https://curity.io/resources/code-examples/status/)
 [![Availability](https://img.shields.io/badge/availability-binary-blue)](https://curity.io/resources/code-examples/status/)
 
 A LUA plugin that is used during API calls from SPA clients, to forward JWTs to APIs.\
@@ -122,9 +122,9 @@ Include here any additional [non-safelisted request headers](https://developer.m
 To implement data changing requests, include the CSRF request header name, eg `x-example-csrf`.\
 A '*' wildcard value should not be configured here, since it will not work with credentialed requests.
 
-#### cors_exposed_headers
+#### cors_expose_headers
 
-> **Syntax**: **`cors_exposed_headers`** `string[]`
+> **Syntax**: **`cors_expose_headers`** `string[]`
 >
 > **Default**: *[]*
 >
@@ -183,7 +183,7 @@ access-control-allow-headers: x-example-csrf
 access-control-max-age: 86400
 ```
 
-The above configuration expands as follows, and you can customize this further if needed:
+If you prefer you can override default settings:
 
 ```text
 local config = {
@@ -196,14 +196,15 @@ local config = {
     allow_tokens = false,
     remove_cookie_headers = true,
     cors_allow_methods = {
-        'OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'
+        'OPTIONS', 'GET', 'POST'
     },
     cors_allow_headers = {
+        'my-header',
         'x-example-csrf'
     },
-    cors_exposed_headers = {
+    cors_expose_headers = {
     },
-    cors_max_age = 86400
+    cors_max_age = 600
 }
 ```
 
@@ -223,15 +224,12 @@ plugins:
       cors_allow_methods:
       - OPTIONS
       - GET
-      - HEAD
       - POST
-      - PUT
-      - PATCH
-      - DELETE
       cors_allow_headers:
+      - my-header
       - x-example-csrf
-      cors_exposed_headers: []
-      cors_max_age: 86400
+      cors_expose_headers: []
+      cors_max_age: 600
 ```
 
 If you prefer you can configure `cors_enabled=false`, in which case you'll need to handle CORS in your API.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All API endpoints will then return these CORS headers to browsers in response he
 ```text
 access-control-allow-origin: http://www.example.com
 access-control-allow-credentials: true
-access-control-allow-methods: OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE
+access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
 access-control-allow-headers: x-example-csrf
 access-control-max-age: 86400
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OAuth Proxy Plugin for NGINX LUA Systems
 
-[![Quality](https://img.shields.io/badge/quality-experiment-red)](https://curity.io/resources/code-examples/status/)
-[![Availability](https://img.shields.io/badge/availability-source-blue)](https://curity.io/resources/code-examples/status/)
+[![Quality](https://img.shields.io/badge/quality-production-green)](https://curity.io/resources/code-examples/status/)
+[![Availability](https://img.shields.io/badge/availability-binary-blue)](https://curity.io/resources/code-examples/status/)
 
 A LUA plugin that is used during API calls from SPA clients, to forward JWTs to APIs.\
 This is part of a `Backend for Frontend` solution for SPAs, in line with [best practices for browser based apps](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps).

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -21,7 +21,8 @@ fi
 #
 # Supply the 32 byte encryption key for AES256 as an environment variable
 #
-export ENCRYPTION_KEY='4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50'
+export ENCRYPTION_KEY=$(openssl rand 32 | xxd -p -c 64)
+echo -n $ENCRYPTION_KEY > encryption.key
 
 #
 # For Kong we must update a template file

--- a/docker/encrypt.js
+++ b/docker/encrypt.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const fs = require('fs');
 const crypto = require('crypto');
 const {exit} = require('process');
-const ENCRYPTION_KEY = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50';
 const GCM_IV_SIZE = 12;
 const CURRENT_VERSION = 1;
 
@@ -14,7 +14,8 @@ try {
     }
 
     const payloadText = args[0];
-    const encryptionKeyBytes = Buffer.from(ENCRYPTION_KEY, 'hex');
+    const encryptionKeyHex = fs.readFileSync('./encryption.key', 'ascii');
+    const encryptionKeyBytes = Buffer.from(encryptionKeyHex, 'hex');
     const ivBytes = crypto.randomBytes(GCM_IV_SIZE);
     const cipher = crypto.createCipheriv('aes-256-gcm', encryptionKeyBytes, ivBytes);
     

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -82,6 +82,12 @@ if [ "$CREDENTIALS" != 'true' ]; then
   exit
 fi
 
+VARY=$(getHeaderValue 'vary')
+if [ "$VARY" != 'origin' ]; then
+  echo '*** The CORS vary response header was not set correctly'
+  exit
+fi
+
 METHODS=$(getHeaderValue 'access-control-allow-methods')
 if [ "$METHODS" != 'OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE' ]; then
   echo '*** The CORS access-control-allow-methods response header was not set correctly'
@@ -151,15 +157,9 @@ if [ "$CREDENTIALS" != 'true' ]; then
   exit
 fi
 
-HEADERS=$(getHeaderValue 'access-control-allow-headers')
-if [ "$HEADERS" != 'x-example-csrf' ]; then
-  echo '*** The CORS access-control-allow-methods response header was not set correctly'
-  exit
-fi
-
-MAXAGE=$(getHeaderValue 'access-control-max-age')
-if [ "$MAXAGE" != '86400' ]; then
-  echo '*** The CORS access-control-max-age response header was not set correctly'
+VARY=$(getHeaderValue 'vary')
+if [ "$VARY" != 'origin' ]; then
+  echo '*** The CORS vary response header was not set correctly'
   exit
 fi
 echo '4. GET request returned all correct CORS headers for a valid web origin'

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -90,7 +90,7 @@ if [ "$VARY" != 'origin,access-control-request-headers' ]; then
 fi
 
 METHODS=$(getHeaderValue 'access-control-allow-methods')
-if [ "$METHODS" != 'OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE' ]; then
+if [ "$METHODS" != 'OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE' ]; then
   echo '*** The CORS access-control-allow-methods response header was not set correctly'
   exit
 fi

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -40,7 +40,7 @@ echo '1. Testing OPTIONS request for an untrusted web origin ...'
 HTTP_STATUS=$(curl -i -s -X OPTIONS "$API_URL" \
 -H "origin: https://malicious-site.com" \
 -o $RESPONSE_FILE -w '%{http_code}')
-if [ "$HTTP_STATUS" != '200' ]; then
+if [ "$HTTP_STATUS" != '204' ]; then
   echo "*** OPTIONS request failed, status: $HTTP_STATUS"
   exit
 fi
@@ -66,7 +66,7 @@ HTTP_STATUS=$(curl -i -s -X OPTIONS "$API_URL" \
 -H "origin: $WEB_ORIGIN" \
 -H "access-control-request-headers: x-example-csrf" \
 -o $RESPONSE_FILE -w '%{http_code}')
-if [ "$HTTP_STATUS" != '200' ]; then
+if [ "$HTTP_STATUS" != '204' ]; then
   echo "*** OPTIONS request failed, status: $HTTP_STATUS"
   exit
 fi

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -64,6 +64,7 @@ echo '1. OPTIONS request successfully denied access to an untrusted web origin'
 echo '2. Testing OPTIONS request for a valid web origin ...'
 HTTP_STATUS=$(curl -i -s -X OPTIONS "$API_URL" \
 -H "origin: $WEB_ORIGIN" \
+-H "access-control-request-headers: x-example-csrf" \
 -o $RESPONSE_FILE -w '%{http_code}')
 if [ "$HTTP_STATUS" != '200' ]; then
   echo "*** OPTIONS request failed, status: $HTTP_STATUS"
@@ -83,7 +84,7 @@ if [ "$CREDENTIALS" != 'true' ]; then
 fi
 
 VARY=$(getHeaderValue 'vary')
-if [ "$VARY" != 'origin' ]; then
+if [ "$VARY" != 'origin,access-control-request-headers' ]; then
   echo '*** The CORS vary response header was not set correctly'
   exit
 fi
@@ -96,7 +97,7 @@ fi
 
 HEADERS=$(getHeaderValue 'access-control-allow-headers')
 if [ "$HEADERS" != 'x-example-csrf' ]; then
-  echo '*** The CORS access-control-allow-methods response header was not set correctly'
+  echo '*** The CORS access-control-allow-headers response header was not set correctly'
   exit
 fi
 

--- a/plugin/plugin.lua
+++ b/plugin/plugin.lua
@@ -64,7 +64,7 @@ local function initialize_configuration(config)
         if method == 'OPTIONS' then
 
             if config.cors_allow_methods == nil then
-                config.cors_allow_methods = {'OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'}
+                config.cors_allow_methods = {'OPTIONS', 'HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'}
             end
 
             if config.cors_max_age == nil then
@@ -250,7 +250,7 @@ function _M.run(config)
     if method == 'OPTIONS' then
         if config.cors_enabled then
             add_cors_response_headers(config, false)
-            ngx.exit(200)
+            ngx.exit(204)
         end
         return
     end

--- a/plugin/plugin.lua
+++ b/plugin/plugin.lua
@@ -135,8 +135,10 @@ local function add_cors_response_headers(config, is_error)
                 if config.cors_max_age > 0 then
                     ngx.header['access-control-max-age'] = config.cors_max_age
                 end
-
-                vary = 'origin,access-control-request-headers'
+                
+                if config.cors_allow_headers == nil then
+                    vary = 'origin,access-control-request-headers'
+                end
             end
 
             if #config.cors_expose_headers > 0 then

--- a/plugin/plugin.lua
+++ b/plugin/plugin.lua
@@ -97,31 +97,34 @@ local function add_cors_response_headers(config, is_error)
     if origin and array_has_value(config.trusted_web_origins, origin) then
 
         if config.cors_enabled or is_error then
-
-            -- For plugin errors we always add these CORS headers, so that the SPA can read the error response body
             ngx.header['access-control-allow-origin'] = origin
             ngx.header['access-control-allow-credentials'] = 'true'
-            if #config.trusted_web_origins > 1 then
-                ngx.header['vary'] = 'origin'
-            end
+            ngx.header['vary'] = 'origin'
         end
 
         if config.cors_enabled then
-
+            
             local method = ngx.req.get_method():upper()
             if method == 'OPTIONS' then
+            
                 if config.cors_allow_methods then
                     local allow_methods_str = table.concat(config.cors_allow_methods, ',')
                     if allow_methods_str then
                         ngx.header['access-control-allow-methods'] = allow_methods_str
                     end
                 end
-            end
 
-            if config.cors_allow_headers then
-                local allow_headers_str = table.concat(config.cors_allow_headers, ',')
-                if allow_headers_str then
-                    ngx.header['access-control-allow-headers'] = allow_headers_str
+                if config.cors_allow_headers then
+                    local allow_headers_str = table.concat(config.cors_allow_headers, ',')
+                    if allow_headers_str then
+                        ngx.header['access-control-allow-headers'] = allow_headers_str
+                    end
+                end
+                
+                if config.cors_max_age then
+                    if config.cors_max_age > 0 then
+                        ngx.header['access-control-max-age'] = config.cors_max_age
+                    end
                 end
             end
 
@@ -129,12 +132,6 @@ local function add_cors_response_headers(config, is_error)
                 local expose_headers_str = table.concat(config.cors_expose_headers, ',')
                 if expose_headers_str then
                     ngx.header['access-control-expose-headers'] = expose_headers_str
-                end
-            end
-            
-            if config.cors_max_age then
-                if config.cors_max_age > 0 then
-                    ngx.header['access-control-max-age'] = config.cors_max_age
                 end
             end
         end

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -14,7 +14,7 @@ return {
                 { cors_enabled = { type = "boolean", required = true } },
                 { cors_allow_methods = { type = "array", required = false, elements = { type = "string" } } },
                 { cors_allow_headers = { type = "array", required = false, elements = { type = "string" } } },
-                { cors_exposed_headers = { type = "array", required = false, elements = { type = "string" } } },
+                { cors_expose_headers = { type = "array", required = false, elements = { type = "string" } } },
                 { cors_max_age = { type = "number", required = false } },
                 { allow_tokens = { type = "boolean", required = false } },
                 { remove_cookie_headers = { type = "boolean", required = false } }

--- a/t/config.t
+++ b/t/config.t
@@ -274,7 +274,4 @@ $data;
 --- response_headers
 access-control-allow-origin: https://www.example.com
 access-control-allow-credentials: true
-access-control-allow-methods:
-access-control-allow-headers: myallowedheader1,myallowedheader2
-access-control-expose-headers: myexposedheader
-access-control-max-age: 600
+vary: origin

--- a/t/config.t
+++ b/t/config.t
@@ -18,7 +18,7 @@ __DATA__
 
 === TEST CONFIG_1: A deployment with empty configuration does not crash NGINX
 ######################################################################################################
-# Verify that null configuration is handled in a controller manner rather than causing server problems
+# Verify that null configuration is handled in a controlled manner rather than causing server problems
 ######################################################################################################
 
 --- config

--- a/t/http_get.t
+++ b/t/http_get.t
@@ -98,7 +98,8 @@ location /t {
             trusted_web_origins = {
                 'https://www.example.com'
             },
-            cors_enabled = true
+            cors_enabled = true,
+            allow_tokens = true
         }
 
         local oauthProxy = require 'oauth-proxy'
@@ -322,9 +323,6 @@ $data;
 --- response_headers
 access-control-allow-origin:
 access-control-allow-credentials:
-access-control-allow-headers:
-access-control-expose-headers:
-access-control-max-age:
 vary:
 
 === TEST HTTP_GET_9: GET with a valid request removes cookie related headers when forwarding to the API
@@ -372,7 +370,7 @@ $data;
 cookie:
 x-example-csrf:
 
-=== TEST HTTP_GET_9: GET with a valid request passes cookie headers through to the API when required
+=== TEST HTTP_GET_10: GET with a valid request passes cookie headers through to the API when required
 ########################################################
 # Ensure that the API can receive cookies if ever needed
 ########################################################
@@ -416,7 +414,7 @@ $data;
 --- reponse_headers eval
 cookie: $main::at_opaque_cookie
 
-=== TEST HTTP_GET_10: GET with a bearer token is allowed when enabled
+=== TEST HTTP_GET_11: GET with a bearer token is allowed when enabled
 ##########################################################################################################
 # Verify that mobile and SPA clients can use the same routes, where the first sends access tokens directly
 ##########################################################################################################
@@ -459,7 +457,7 @@ authorization: Bearer xxx
 --- reponse_headers
 authorization: Bearer xxx
 
-=== TEST HTTP_GET_11: GET with a bearer token is denied when not enabled
+=== TEST HTTP_GET_12: GET with a bearer token is denied when not enabled
 #######################################################################################################
 # Verify that if a company wants to force mobile and SPA clients to use different routes they can do so
 #######################################################################################################

--- a/t/http_get.t
+++ b/t/http_get.t
@@ -278,9 +278,7 @@ $data;
 --- response_headers
 access-control-allow-origin: http://www.example.com
 access-control-allow-credentials: true
-access-control-allow-headers: x-mycompany-myproduct-csrf
-access-control-expose-headers:
-access-control-max-age: 86400
+vary: origin
 
 === TEST HTTP_GET_8: GET with a valid request and CORS disabled does not return CORS response headers
 ###########################################################################
@@ -327,6 +325,7 @@ access-control-allow-credentials:
 access-control-allow-headers:
 access-control-expose-headers:
 access-control-max-age:
+vary:
 
 === TEST HTTP_GET_9: GET with a valid request removes cookie related headers when forwarding to the API
 #########################################################################

--- a/t/http_options.t
+++ b/t/http_options.t
@@ -264,7 +264,7 @@ access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
 access-control-allow-headers: x-example-csrf,other
 access-control-expose-headers:
 access-control-max-age: 86400
-vary: origin,access-control-request-headers
+vary: origin
 
 === TEST HTTP_OPTIONS_7: OPTIONS with custom expose headers returns expected headers
 ######################################################################

--- a/t/http_options.t
+++ b/t/http_options.t
@@ -1,0 +1,352 @@
+#!/usr/bin/perl
+
+##########################################################################
+# Runs OPTIONS tests to verify security behavior from a client's viewpoint
+##########################################################################
+
+use strict;
+use warnings;
+use Test::Nginx::Socket 'no_plan';
+
+SKIP: {
+    run_tests();
+}
+
+__DATA__
+
+=== TEST HTTP_OPTIONS_1: OPTIONS without CORS returns no headers
+#########################################################################
+# Ensure that CORS headers can be handled by an API when CORS is disabled
+#########################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = false
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+
+    proxy_pass http://localhost:1984/target;
+}
+location /target {
+    add_header 'access-control-allow-origin' '*';
+    return 200;
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.example.com
+
+--- error_code: 200
+
+--- response_headers
+access-control-allow-origin: *
+
+=== TEST HTTP_OPTIONS_2: OPTIONS with CORS and untrusted origin returns no CORS headers
+###################################################################
+# Ensure that CORS headers do not grant access to untrusted origins
+###################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = true
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.malicious-site.com
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin:
+access-control-allow-credentials:
+access-control-allow-methods:
+access-control-allow-headers:
+access-control-expose-headers:
+access-control-max-age:
+vary:
+
+=== TEST HTTP_OPTIONS_3: OPTIONS with CORS and valid origin returns expected default headers
+######################################################################
+# Ensure that CORS headers are correctly returned for a trusted origin
+######################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.other.com',
+                'https://www.example.com'
+            },
+            cors_enabled = true
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.example.com
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin: https://www.example.com
+access-control-allow-credentials: true
+access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
+access-control-allow-headers:
+access-control-expose-headers:
+access-control-max-age: 86400
+vary: origin,access-control-request-headers
+
+=== TEST HTTP_OPTIONS_4: OPTIONS with runtime headers returns those requested by the SPA
+###########################################################################################################
+# Ensure that CORS runtime headers are correctly allowed by the OAuth proxy, when default settings are used
+###########################################################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = true
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers eval
+my $data;
+$data .= "origin: https://www.example.com\n";
+$data .= "access-control-request-headers: x-example-csrf, first, second\n";
+$data;
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin: https://www.example.com
+access-control-allow-credentials: true
+access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
+access-control-allow-headers: x-example-csrf,first,second
+access-control-expose-headers:
+access-control-max-age: 86400
+vary: origin,access-control-request-headers
+
+=== TEST HTTP_OPTIONS_5: OPTIONS with custom allowed methods returns expected headers
+#####################################################################
+# Ensure that custom CORS allow methods can be returned if configured
+#####################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = true,
+            cors_allow_methods = {
+                'GET',
+                'POST'
+            }
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.example.com
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin: https://www.example.com
+access-control-allow-credentials: true
+access-control-allow-methods: GET,POST
+access-control-allow-headers:
+access-control-expose-headers:
+access-control-max-age: 86400
+vary: origin,access-control-request-headers
+
+=== TEST HTTP_OPTIONS_6: OPTIONS with custom allowed headers returns expected headers
+#####################################################################
+# Ensure that custom CORS allow headers can be returned if configured
+#####################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = true,
+            cors_allow_headers = {
+                'x-example-csrf',
+                'other'
+            }
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.example.com
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin: https://www.example.com
+access-control-allow-credentials: true
+access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
+access-control-allow-headers: x-example-csrf,other
+access-control-expose-headers:
+access-control-max-age: 86400
+vary: origin,access-control-request-headers
+
+=== TEST HTTP_OPTIONS_7: OPTIONS with custom expose headers returns expected headers
+######################################################################
+# Ensure that custom CORS expose headers can be returned if configured
+######################################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = true,
+            cors_expose_headers = {
+                'first',
+                'second'
+            }
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.example.com
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin: https://www.example.com
+access-control-allow-credentials: true
+access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
+access-control-allow-headers:
+access-control-expose-headers: first,second
+access-control-max-age: 86400
+vary: origin,access-control-request-headers
+
+=== TEST HTTP_OPTIONS_8: OPTIONS with custom max age returns expected headers
+###############################################################
+# Ensure that custom CORS max age can be returned if configured
+###############################################################
+
+--- config
+location /t {
+    rewrite_by_lua_block {
+
+        local config = {
+            cookie_name_prefix = 'example',
+            encryption_key = '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
+            trusted_web_origins = {
+                'https://www.example.com'
+            },
+            cors_enabled = true,
+            cors_max_age = 600
+        }
+
+        local oauthProxy = require 'oauth-proxy'
+        oauthProxy.run(config)
+    }
+}
+
+--- request
+OPTIONS /t
+
+--- more_headers
+origin: https://www.example.com
+
+--- error_code: 204
+
+--- response_headers
+access-control-allow-origin: https://www.example.com
+access-control-allow-credentials: true
+access-control-allow-methods: OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE
+access-control-allow-headers:
+access-control-expose-headers:
+access-control-max-age: 600
+vary: origin,access-control-request-headers

--- a/wiki/wiki.md
+++ b/wiki/wiki.md
@@ -101,6 +101,13 @@ Or run Kong and the plugin, with a configuration that routes to a minimal REST A
 Call the API at http://localhost:3000, which will initially return an unauthorized error.\
 The gateway logs are visible in the terminal window for troubleshooting.
 
+```curl
+AT_COOKIE='AcYBf995tTBVsLtQLvOuLUZXHm2c-XqP8t7SKmhBiQtzy5CAw4h_RF6rXyg6kHrvhb8x4WaLQC6h3mw6a3O3Q9A'
+curl -i -X GET http://localhost:3000/api \
+-H "origin: http://www.example.com" \
+-H "cookie: example-at=$AT_COOKIE"
+```
+
 ## Run HTTP Tests
 
 Next run some curl based tests in another terminal window:


### PR DESCRIPTION
The main focus here was to add CORS headers more correctly according to Mozilla docs:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers

These headers should only be returned on pre-flight requests:
- access-control-allow-methods
- access-control-allow-headers
- access-control-max-age

Also copied the technique from Express CORS where if no headers are specified, use those from this request header:
- access-control-request-header

Other changes are just test updates and generating a new encryption key for every deployment, rather than hard coding.