### PR TITLE
Fix rockspec files and demonstrate luarocks make

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:16.6.0-alpine
 WORKDIR /usr/api
-COPY api/api.js /usr/api
+COPY docker/api/api.js /usr/api
 CMD ["node", "api.js"]

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -5,9 +5,10 @@
 ######################################################################
 
 #
-# Ensure that we are in the folder containing this script
+# Ensure that we are in the root folder
 #
 cd "$(dirname "${BASH_SOURCE[0]}")"
+cd ..
 
 #
 # Get command line arguments
@@ -22,16 +23,16 @@ fi
 # Supply the 32 byte encryption key for AES256 as an environment variable
 #
 export ENCRYPTION_KEY=$(openssl rand 32 | xxd -p -c 64)
-echo -n $ENCRYPTION_KEY > encryption.key
+echo -n $ENCRYPTION_KEY > docker/encryption.key
 
 #
 # For Kong we must update a template file
 #
 if [ "$PROFILE" == 'kong' ]; then
-  envsubst < kong/kong.template.yml > ./kong/kong.yml
+  envsubst < docker/kong/kong.template.yml > docker/kong/kong.yml
 fi
 
 #
 # Deploy the system
 #
-docker compose --profile "$PROFILE" --project-name oauthproxy up --build --force-recreate
+docker compose --file ./docker/docker-compose.yml --profile "$PROFILE" --project-name oauthproxy up --build --force-recreate

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -33,6 +33,19 @@ if [ "$PROFILE" == 'kong' ]; then
 fi
 
 #
+# Build a custom Docker image, which uses 'luarocks make' to deploy the plugin
+#
+if [ "$PROFILE" == 'kong' ]; then
+  docker build -f docker/kong/Dockerfile --no-cache -t custom_kong:2.6.0-alpine .
+else
+  docker build -f docker/openresty/Dockerfile --no-cache -t custom_openresty:1.19.9.1-bionic .
+fi
+if [ $? -ne 0 ]; then
+  echo "Problem encountered building the OAuth Proxy Docker file"
+  exit 1
+fi  
+
+#
 # Deploy the system
 #
 docker compose --file ./docker/docker-compose.yml --profile "$PROFILE" --project-name oauthproxy up --build --force-recreate

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,17 +7,13 @@ services:
   kong:
     image: custom_kong:2.6.0-alpine
     build:
-      context: .
-      dockerfile: ./kong/Dockerfile
+      context: ..
+      dockerfile: ./docker/kong/Dockerfile
     hostname: kongserver
     ports:
       - 3000:3000
     volumes:
       - ./kong/kong.yml:/usr/local/kong/declarative/kong.yml
-      - ../plugin/plugin.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/access.lua
-      - ../plugin/handler.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/handler.lua
-      - ../plugin/schema.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/schema.lua
-      - ../plugin/kong-oauth-proxy-1.0.0-1.rockspec:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/oauth-proxy-1.0.0-1.rockspec
     environment:
       KONG_DATABASE: 'off'
       KONG_DECLARATIVE_CONFIG: '/usr/local/kong/declarative/kong.yml'
@@ -33,14 +29,13 @@ services:
   openresty:
     image: custom_openresty/openresty:1.19.9.1-bionic
     build:
-      context: .
-      dockerfile: ./openresty/Dockerfile
+      context: ..
+      dockerfile: ./docker/openresty/Dockerfile
     hostname: openrestyserver
     ports:
       - 3000:3000
     volumes:
       - ./openresty/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
-      - ../plugin/plugin.lua:/usr/local/openresty/lualib/oauth-proxy.lua
     environment:
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
     profiles:
@@ -52,5 +47,5 @@ services:
   business-api:
     hostname: apiserver
     build:
-      context: .
-      dockerfile: ./api/Dockerfile
+      context: ..
+      dockerfile: ./docker/api/Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,9 +6,6 @@ services:
   #
   kong:
     image: custom_kong:2.6.0-alpine
-    build:
-      context: ..
-      dockerfile: ./docker/kong/Dockerfile
     hostname: kongserver
     ports:
       - 3000:3000
@@ -27,10 +24,7 @@ services:
   # Use OpenResty as the reverse proxy when the openresty profile is set on the command line
   #
   openresty:
-    image: custom_openresty/openresty:1.19.9.1-bionic
-    build:
-      context: ..
-      dockerfile: ./docker/openresty/Dockerfile
+    image: custom_openresty:1.19.9.1-bionic
     hostname: openrestyserver
     ports:
       - 3000:3000

--- a/docker/kong/Dockerfile
+++ b/docker/kong/Dockerfile
@@ -1,4 +1,9 @@
 FROM kong:2.6.0-alpine
+
+# Deploy the plugin and dependencies for local testing
 USER root
-RUN luarocks install lua-resty-openssl
+COPY ./plugin/*.lua          /tmp/oauth-proxy/
+COPY ./plugin/kong*.rockspec /tmp/oauth-proxy/
+RUN cd /tmp/oauth-proxy/ && luarocks make kong-oauth-proxy-1.0.0-1.rockspec
+
 USER kong

--- a/docker/openresty/Dockerfile
+++ b/docker/openresty/Dockerfile
@@ -1,2 +1,6 @@
 FROM openresty/openresty:1.19.9.1-bionic
-RUN luarocks install lua-resty-openssl
+
+# Deploy the plugin and dependencies for local testing
+COPY ./plugin/plugin.lua    /tmp/oauth-proxy/
+COPY ./plugin/lua*.rockspec /tmp/oauth-proxy/
+RUN cd /tmp/oauth-proxy/ && luarocks make lua-resty-oauth-proxy-1.0.0-1.rockspec

--- a/docker/openresty/nginx.conf
+++ b/docker/openresty/nginx.conf
@@ -46,7 +46,7 @@ http {
                     allow_tokens = true
                 }
 
-                local oauthProxy = require 'oauth-proxy'
+                local oauthProxy = require 'resty.oauth-proxy'
                 oauthProxy.run(config)
             }
 

--- a/plugin/kong-oauth-proxy-1.0.0-1.rockspec
+++ b/plugin/kong-oauth-proxy-1.0.0-1.rockspec
@@ -1,10 +1,10 @@
-package = "curity-oauth-proxy"
+package = "kong-oauth-proxy"
 version = "1.0.0-1"
 source = {
   url = "https://github.com/curityio/nginx-lua-oauth-proxy-plugin"
 }
 description = {
-  summary = "A Kong plugin used during API requests to deal with CORS and cookies, then forward access tokens",
+  summary = "A plugin used during API requests to deal with CORS and cookies, then forward access tokens",
   homepage = "https://curity.io/product/token-service/oauth-for-web/",
   license = "Apache 2.0",
   detailed = [[
@@ -17,16 +17,17 @@ description = {
         It then decrypts secure cookies to get the access token contained.
         The access token is then forwarded to the API using the HTTP Authorization header.
         All of this provides strongest browser security without needing any API code changes.
-    ]]
+  ]],
   summary = "A Kong plugin used during API requests to deal with CORS and cookies, then forward access tokens"
 }
 dependencies = {
-  "lua >= 5.1"
+  "lua >= 5.1",
+  "lua-resty-openssl >= 0.8.4"
 }
 build = {
   type = "builtin",
   modules = {
-    ["kong.plugins.oauth-proxy.access"]  = "access.lua",
+    ["kong.plugins.oauth-proxy.access"]  = "plugin.lua",
     ["kong.plugins.oauth-proxy.handler"] = "handler.lua",
     ["kong.plugins.oauth-proxy.schema"]  = "schema.lua"
   }

--- a/plugin/lua-resty-oauth-proxy-1.0.0-1.rockspec
+++ b/plugin/lua-resty-oauth-proxy-1.0.0-1.rockspec
@@ -1,10 +1,10 @@
-package = "curity-oauth-proxy"
+package = "lua-resty-oauth-proxy"
 version = "1.0.0-1"
 source = {
   url = "https://github.com/curityio/nginx-lua-oauth-proxy-plugin"
 }
 description = {
-  summary = "An OpenResty plugin used during API requests to deal with CORS and cookies, then forward access tokens",
+  summary = "A LUA plugin used during API requests to deal with CORS and cookies, then forward access tokens",
   homepage = "https://curity.io/product/token-service/oauth-for-web/",
   license = "Apache 2.0",
   detailed = [[
@@ -17,11 +17,12 @@ description = {
         It then decrypts secure cookies to get the access token contained.
         The access token is then forwarded to the API using the HTTP Authorization header.
         All of this provides strongest browser security without needing any API code changes.
-    ]]
+  ]],
+  summary = "A LUA plugin used during API requests to deal with CORS and cookies, then forward access tokens"
 }
 dependencies = {
-    "lua >= 5.1",
-    "lua-resty-openssl >= 0.8.4"
+  "lua >= 5.1",
+  "lua-resty-openssl >= 0.8.4"
 }
 build = {
   type = "builtin",

--- a/wiki/wiki.md
+++ b/wiki/wiki.md
@@ -46,7 +46,7 @@ location /t {
             cors_enabled = true
         }
 
-        local oauthProxy = require 'oauth-proxy'
+        local oauthProxy = require 'resty.oauth-proxy'
         oauthProxy.run(config)
     }
     


### PR DESCRIPTION
We will do more work in future, but for now this is a small release with value:
- Fixes up rockspec files, which were invalid previously
- As part of LUA development, we continually verify that 'luarocks make' works, during Docker deployment

I will do more work before updating the main SPA repo, so that the phantom token module works equivalently. Ideally I would like to use 'luarocks install' in the SPA demo deployment - though we may do 'luarocks make' as an intermediate step.