### PR TITLE
Fix broken tests with latest openresty

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See also the following resources:
 If you are using luarocks, execute the following command to install the plugin:
 
 ```bash
-luarocks install kong-oauth-proxy 1.3.0
+luarocks install kong-oauth-proxy 1.3.1
 ```
 
 Or deploy the .lua files into Kong's plugin directory, eg `/usr/local/share/lua/5.1/kong/plugins/oauth-proxy`.
@@ -45,7 +45,7 @@ Or deploy the .lua files into Kong's plugin directory, eg `/usr/local/share/lua/
 If you are using luarocks, execute the following command to install the plugin:
 
 ```bash
-luarocks install lua-resty-oauth-proxy 1.3.0
+luarocks install lua-resty-oauth-proxy 1.3.1
 ```
 
 Or deploy the `access.lua` file to `resty/oauth-proxy.lua`, where the resty folder is in the `lua_package_path`.\

--- a/kong-oauth-proxy-1.3.1-1.rockspec
+++ b/kong-oauth-proxy-1.3.1-1.rockspec
@@ -1,8 +1,8 @@
 package = "kong-oauth-proxy"
-version = "1.3.0-1"
+version = "1.3.1-1"
 source = {
   url = "git://github.com/curityio/nginx-lua-oauth-proxy-plugin",
-  tag = "v1.3.0"
+  tag = "v1.3.1"
 }
 description = {
   summary = "A plugin used during API requests to deal with CORS and cookies, then forward access tokens",
@@ -23,7 +23,7 @@ description = {
 }
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-openssl >= 0.8.4"
+  "lua-resty-openssl >= 1.4.0"
 }
 build = {
   type = "builtin",

--- a/lua-resty-oauth-proxy-1.3.1-1.rockspec
+++ b/lua-resty-oauth-proxy-1.3.1-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-oauth-proxy"
-version = "1.3.0-1"
+version = "1.3.1-1"
 source = {
   url = "git://github.com/curityio/nginx-lua-oauth-proxy-plugin",
-  tag = "v1.3.0"
+  tag = "v1.3.1"
 }
 description = {
   summary = "A LUA plugin used during API requests to deal with CORS and cookies, then forward access tokens",
@@ -23,7 +23,7 @@ description = {
 }
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-openssl >= 0.8.4"
+  "lua-resty-openssl >= 1.4.0"
 }
 build = {
   type = "builtin",

--- a/plugin/handler.lua
+++ b/plugin/handler.lua
@@ -7,7 +7,7 @@ local access = require "kong.plugins.oauth-proxy.access"
 -- See https://github.com/Kong/kong/discussions/7193 for more about the PRIORITY field
 local TokenHandler = {
     PRIORITY = 2000,
-    VERSION = "1.3.0",
+    VERSION = "1.3.1",
 }
 
 function TokenHandler:access(conf)

--- a/t/config.t
+++ b/t/config.t
@@ -198,7 +198,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;
@@ -253,7 +253,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;

--- a/t/decryption.t
+++ b/t/decryption.t
@@ -82,7 +82,7 @@ location /t {
         oauthProxy.run(config)
     }
 
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;
@@ -127,7 +127,7 @@ location /t {
         oauthProxy.run(config)
     }
 
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;

--- a/t/http_get.t
+++ b/t/http_get.t
@@ -216,7 +216,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;
@@ -259,7 +259,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     return 200;
@@ -303,7 +303,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     return 200;
@@ -347,7 +347,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'cookie' $http_cookie;
@@ -392,7 +392,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'cookie' $http_cookie;
@@ -438,7 +438,7 @@ location /t {
         oauthProxy.run(config)
     }
 
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;
@@ -480,7 +480,7 @@ location /t {
         oauthProxy.run(config)
     }
 
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 
 --- request
@@ -518,7 +518,7 @@ location /t {
         oauthProxy.run(config)
     }
     
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;

--- a/t/http_options.t
+++ b/t/http_options.t
@@ -36,7 +36,7 @@ location /t {
         oauthProxy.run(config)
     }
 
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'access-control-allow-origin' '*';

--- a/t/http_post.t
+++ b/t/http_post.t
@@ -158,7 +158,7 @@ location /t {
         oauthProxy.run(config)
     }
 
-    proxy_pass http://localhost:1984/target;
+    proxy_pass http://127.0.0.1:1984/target;
 }
 location /target {
     add_header 'authorization' $http_authorization;
@@ -204,7 +204,7 @@ location /api {
     }
 
     location /api/products {
-        proxy_pass http://localhost:1984/target;
+        proxy_pass http://127.0.0.1:1984/target;
     } 
 }
 location /target {

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 #
 # Point to the OpenResty install
 #
-OPENRESTY_ROOT=/usr/local/Cellar/openresty/1.21.4.1_1
+OPENRESTY_ROOT=/usr/local/Cellar/openresty/1.25.3.1_1
 
 #
 # Ensure that the OpenResty nginx, with LUA support, will be found by the prove tool


### PR DESCRIPTION
Tests were failing with the latest openresty so I updated from locahost to 127.0.0.1 to fix it.
I will release a new version to luarocks once merged.
Also used an up to date version of the openssl dependency.